### PR TITLE
Forced use of centos 6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:centos6
 MAINTAINER Dennis Kanbier <dennis@kanbier.net>
 
 # Update base images.


### PR DESCRIPTION
Since the release of centos 7, this container is no longer building correctly:

```
Step 8 : RUN yum -y -q localinstall --nogpgcheck /tmp/zabbix-server-mysql-2.4.0-1.el6.x86_64.rpm
 ---> Running in 098be717ae78
Error: Package: iksemel-1.4-2.el6.x86_64 (epel)
           Requires: libgnutls.so.26(GNUTLS_1_4)(64bit)
Error: Package: zabbix-server-mysql-2.4.0-1.el6.x86_64 (/zabbix-server-mysql-2.4.0-1.el6.x86_64)
           Requires: libnetsnmp.so.20()(64bit)
Error: Package: zabbix-server-mysql-2.4.0-1.el6.x86_64 (/zabbix-server-mysql-2.4.0-1.el6.x86_64)
           Requires: libmysqlclient.so.16()(64bit)
Error: Package: zabbix-server-mysql-2.4.0-1.el6.x86_64 (/zabbix-server-mysql-2.4.0-1.el6.x86_64)
           Requires: libmysqlclient.so.16(libmysqlclient_16)(64bit)
Error: Package: iksemel-1.4-2.el6.x86_64 (epel)
           Requires: libgnutls.so.26()(64bit)
 You could try using --skip-broken to work around the problem
** Found 1 pre-existing rpmdb problem(s), 'yum check' output follows:
fakesystemd-1-17.el7.centos.noarch has installed conflicts systemd: fakesystemd-1-17.el7.centos.noarch
2014/11/13 08:36:09 The command [/bin/sh -c yum -y -q localinstall --nogpgcheck /tmp/zabbix-server-mysql-2.4.0-1.el6.x86_64.rpm] returned a non-zero code: 1
```

This is a simple workaround forcing the use of centos6
